### PR TITLE
Update CMake for WPO and 17.5

### DIFF
--- a/d3d11game_uwp_cppwinrt/CMakeLists.txt
+++ b/d3d11game_uwp_cppwinrt/CMakeLists.txt
@@ -100,6 +100,10 @@ elseif ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
         target_compile_options(${PROJECT_NAME} PRIVATE /analyze)
     endif()
 
+    if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Gy /Gw)
+    endif()
+
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.24)
         target_compile_options(${PROJECT_NAME} PRIVATE /ZH:SHA_256)
     endif()
@@ -122,6 +126,10 @@ elseif ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.34)
         target_compile_options(${PROJECT_NAME} PRIVATE /wd5262 /wd5264)
+    endif()
+
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
     endif()
 
     if(BUILD_TEST_TEMPLATE)

--- a/d3d11game_uwp_cppwinrt/CMakePresets.json
+++ b/d3d11game_uwp_cppwinrt/CMakePresets.json
@@ -59,7 +59,11 @@
     },
     {
       "name": "Release",
-      "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" },
+      "cacheVariables":
+      {
+          "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+          "CMAKE_INTERPROCEDURAL_OPTIMIZATION": true
+      },
       "hidden": true
     },
     {

--- a/d3d11game_uwp_cppwinrt_dr/CMakeLists.txt
+++ b/d3d11game_uwp_cppwinrt_dr/CMakeLists.txt
@@ -102,6 +102,10 @@ elseif ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
         target_compile_options(${PROJECT_NAME} PRIVATE /analyze)
     endif()
 
+    if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Gy /Gw)
+    endif()
+
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.24)
         target_compile_options(${PROJECT_NAME} PRIVATE /ZH:SHA_256)
     endif()
@@ -124,6 +128,10 @@ elseif ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.34)
         target_compile_options(${PROJECT_NAME} PRIVATE /wd5262 /wd5264)
+    endif()
+
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
     endif()
 
     if(BUILD_TEST_TEMPLATE)

--- a/d3d11game_uwp_cppwinrt_dr/CMakePresets.json
+++ b/d3d11game_uwp_cppwinrt_dr/CMakePresets.json
@@ -59,7 +59,11 @@
     },
     {
       "name": "Release",
-      "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" },
+      "cacheVariables":
+      {
+          "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+          "CMAKE_INTERPROCEDURAL_OPTIMIZATION": true
+      },
       "hidden": true
     },
     {

--- a/d3d11game_win32/CMakeLists.txt
+++ b/d3d11game_win32/CMakeLists.txt
@@ -113,6 +113,10 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
         target_compile_options(${PROJECT_NAME} PRIVATE /analyze)
     endif()
 
+    if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Gy /Gw)
+    endif()
+
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.24)
         target_compile_options(${PROJECT_NAME} PRIVATE /ZH:SHA_256)
     endif()
@@ -131,6 +135,10 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.34)
         target_compile_options(${PROJECT_NAME} PRIVATE /wd5262 /wd5264)
+    endif()
+
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
     endif()
 
     if(BUILD_TEST_TEMPLATE)

--- a/d3d11game_win32/CMakePresets.json
+++ b/d3d11game_win32/CMakePresets.json
@@ -46,7 +46,11 @@
     },
     {
       "name": "Release",
-      "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" },
+      "cacheVariables":
+      {
+          "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+          "CMAKE_INTERPROCEDURAL_OPTIMIZATION": true
+      },
       "hidden": true
     },
 

--- a/d3d11game_win32_dr/CMakeLists.txt
+++ b/d3d11game_win32_dr/CMakeLists.txt
@@ -115,6 +115,10 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
         target_compile_options(${PROJECT_NAME} PRIVATE /analyze)
     endif()
 
+    if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Gy /Gw)
+    endif()
+
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.24)
         target_compile_options(${PROJECT_NAME} PRIVATE /ZH:SHA_256)
     endif()
@@ -133,6 +137,10 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.34)
         target_compile_options(${PROJECT_NAME} PRIVATE /wd5262 /wd5264)
+    endif()
+
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
     endif()
 
     if(BUILD_TEST_TEMPLATE)

--- a/d3d11game_win32_dr/CMakePresets.json
+++ b/d3d11game_win32_dr/CMakePresets.json
@@ -46,7 +46,11 @@
     },
     {
       "name": "Release",
-      "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" },
+      "cacheVariables":
+      {
+          "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+          "CMAKE_INTERPROCEDURAL_OPTIMIZATION": true
+      },
       "hidden": true
     },
 

--- a/d3d12game_uwp_cppwinrt/CMakeLists.txt
+++ b/d3d12game_uwp_cppwinrt/CMakeLists.txt
@@ -104,6 +104,10 @@ elseif ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
         target_compile_options(${PROJECT_NAME} PRIVATE /analyze)
     endif()
 
+    if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Gy /Gw)
+    endif()
+
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.24)
         target_compile_options(${PROJECT_NAME} PRIVATE /ZH:SHA_256)
     endif()
@@ -126,6 +130,10 @@ elseif ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.34)
         target_compile_options(${PROJECT_NAME} PRIVATE /wd5262 /wd5264)
+    endif()
+
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
     endif()
 
     if(BUILD_TEST_TEMPLATE)

--- a/d3d12game_uwp_cppwinrt/CMakePresets.json
+++ b/d3d12game_uwp_cppwinrt/CMakePresets.json
@@ -59,7 +59,11 @@
     },
     {
       "name": "Release",
-      "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" },
+      "cacheVariables":
+      {
+          "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+          "CMAKE_INTERPROCEDURAL_OPTIMIZATION": true
+      },
       "hidden": true
     },
     {

--- a/d3d12game_uwp_cppwinrt_dr/CMakeLists.txt
+++ b/d3d12game_uwp_cppwinrt_dr/CMakeLists.txt
@@ -106,6 +106,10 @@ elseif ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
         target_compile_options(${PROJECT_NAME} PRIVATE /analyze)
     endif()
 
+    if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Gy /Gw)
+    endif()
+
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.24)
         target_compile_options(${PROJECT_NAME} PRIVATE /ZH:SHA_256)
     endif()
@@ -128,6 +132,10 @@ elseif ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.34)
         target_compile_options(${PROJECT_NAME} PRIVATE /wd5262 /wd5264)
+    endif()
+
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
     endif()
 
     if(BUILD_TEST_TEMPLATE)

--- a/d3d12game_uwp_cppwinrt_dr/CMakePresets.json
+++ b/d3d12game_uwp_cppwinrt_dr/CMakePresets.json
@@ -59,7 +59,11 @@
     },
     {
       "name": "Release",
-      "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" },
+      "cacheVariables":
+      {
+          "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+          "CMAKE_INTERPROCEDURAL_OPTIMIZATION": true
+      },
       "hidden": true
     },
     {

--- a/d3d12game_win32/CMakeLists.txt
+++ b/d3d12game_win32/CMakeLists.txt
@@ -130,6 +130,10 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
         target_compile_options(${PROJECT_NAME} PRIVATE /analyze)
     endif()
 
+    if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Gy /Gw)
+    endif()
+
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.24)
         target_compile_options(${PROJECT_NAME} PRIVATE /ZH:SHA_256)
     endif()
@@ -148,6 +152,10 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
 
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.34)
         target_compile_options(${PROJECT_NAME} PRIVATE /wd5262 /wd5264)
+    endif()
+
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
     endif()
 
     if(BUILD_TEST_TEMPLATE)

--- a/d3d12game_win32/CMakePresets.json
+++ b/d3d12game_win32/CMakePresets.json
@@ -46,7 +46,11 @@
     },
     {
       "name": "Release",
-      "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" },
+      "cacheVariables":
+      {
+          "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+          "CMAKE_INTERPROCEDURAL_OPTIMIZATION": true
+      },
       "hidden": true
     },
 

--- a/d3d12game_win32_dr/CMakeLists.txt
+++ b/d3d12game_win32_dr/CMakeLists.txt
@@ -132,6 +132,10 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
         target_compile_options(${PROJECT_NAME} PRIVATE /analyze)
     endif()
 
+    if(CMAKE_INTERPROCEDURAL_OPTIMIZATION)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Gy /Gw)
+    endif()
+
     if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.24)
         target_compile_options(${PROJECT_NAME} PRIVATE /ZH:SHA_256)
     endif()

--- a/d3d12game_win32_dr/CMakePresets.json
+++ b/d3d12game_win32_dr/CMakePresets.json
@@ -46,7 +46,11 @@
     },
     {
       "name": "Release",
-      "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" },
+      "cacheVariables":
+      {
+          "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+          "CMAKE_INTERPROCEDURAL_OPTIMIZATION": true
+      },
       "hidden": true
     },
 


### PR DESCRIPTION
* Added support for WPO when using the 'x64-Release' preset
* Added some conformance switches for VS 2022 17.5
