### PR TITLE
Fix CMake problem with /Zc:templateScope on older Windows SDKs

### DIFF
--- a/d3d11game_uwp_cppwinrt/CMakeLists.txt
+++ b/d3d11game_uwp_cppwinrt/CMakeLists.txt
@@ -135,7 +135,7 @@ elseif ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     endif()
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
-        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:checkGwOdr $<$<VERSION_GREATER_EQUAL:${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION},10.0.22000>:/Zc:templateScope>)
     endif()
 
     if(BUILD_TEST_TEMPLATE)

--- a/d3d11game_uwp_cppwinrt_dr/CMakeLists.txt
+++ b/d3d11game_uwp_cppwinrt_dr/CMakeLists.txt
@@ -137,7 +137,7 @@ elseif ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     endif()
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
-        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:checkGwOdr $<$<VERSION_GREATER_EQUAL:${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION},10.0.22000>:/Zc:templateScope>)
     endif()
 
     if(BUILD_TEST_TEMPLATE)

--- a/d3d11game_win32/CMakeLists.txt
+++ b/d3d11game_win32/CMakeLists.txt
@@ -144,7 +144,7 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     endif()
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
-        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:checkGwOdr $<$<VERSION_GREATER_EQUAL:${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION},10.0.22000>:/Zc:templateScope>)
     endif()
 
     if(BUILD_TEST_TEMPLATE)

--- a/d3d11game_win32_dr/CMakeLists.txt
+++ b/d3d11game_win32_dr/CMakeLists.txt
@@ -146,7 +146,7 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     endif()
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
-        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:checkGwOdr $<$<VERSION_GREATER_EQUAL:${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION},10.0.22000>:/Zc:templateScope>)
     endif()
 
     if(BUILD_TEST_TEMPLATE)

--- a/d3d12game_uwp_cppwinrt/CMakeLists.txt
+++ b/d3d12game_uwp_cppwinrt/CMakeLists.txt
@@ -139,7 +139,7 @@ elseif ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     endif()
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
-        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:checkGwOdr $<$<VERSION_GREATER_EQUAL:${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION},10.0.22000>:/Zc:templateScope>)
     endif()
 
     if(BUILD_TEST_TEMPLATE)

--- a/d3d12game_uwp_cppwinrt_dr/CMakeLists.txt
+++ b/d3d12game_uwp_cppwinrt_dr/CMakeLists.txt
@@ -141,7 +141,7 @@ elseif ( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     endif()
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
-        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:checkGwOdr $<$<VERSION_GREATER_EQUAL:${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION},10.0.22000>:/Zc:templateScope>)
     endif()
 
     if(BUILD_TEST_TEMPLATE)

--- a/d3d12game_win32/CMakeLists.txt
+++ b/d3d12game_win32/CMakeLists.txt
@@ -161,7 +161,7 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     endif()
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
-        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:checkGwOdr $<$<VERSION_GREATER_EQUAL:${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION},10.0.22000>:/Zc:templateScope>)
     endif()
 
     if(BUILD_TEST_TEMPLATE)

--- a/d3d12game_win32_dr/CMakeLists.txt
+++ b/d3d12game_win32_dr/CMakeLists.txt
@@ -163,7 +163,7 @@ elseif( CMAKE_CXX_COMPILER_ID MATCHES "MSVC" )
     endif()
 
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 19.35)
-        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:templateScope /Zc:checkGwOdr)
+        target_compile_options(${PROJECT_NAME} PRIVATE /Zc:checkGwOdr $<$<VERSION_GREATER_EQUAL:${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION},10.0.22000>:/Zc:templateScope>)
     endif()
 
     if(BUILD_TEST_TEMPLATE)


### PR DESCRIPTION
When building with CMake and VS 2022 Update 5 or later, I make use of ``/Zc:templateScope`` for conformance validation. This is, however, not compatible with the Windows SDK prior to the Windows SDK (22000) build.