### PR TITLE
Update powershell scripts to get latest commit id from GitHub

### DIFF
--- a/VSIX/createcmake.ps1
+++ b/VSIX/createcmake.ps1
@@ -76,7 +76,7 @@ param (
     [string]$TargetDir = "$Env:USERPROFILE\source"
 )
 
-$vcpkgBaseline = "670f6dddaafc59c5dfe0587a130d59a35c48ea38"
+$vcpkgBaseline = "f3e10653cc27d62a37a3763cd84b38bca07c6075"
 
 $reporoot = Split-Path -Path $PSScriptRoot -Parent
 
@@ -140,6 +140,17 @@ Copy-Item ($TemplateDir + "\CMakeLists.txt") -Destination $TargetDir
 Copy-Item ($TemplateDir + "\CMake*.json") -Destination $TargetDir
 
 if (Test-Path -Path ($TemplateDir + "\vcpkg.json")) {
+
+    try {
+        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/microsoft/vcpkg/commits/master" `
+            -Headers @{ "User-Agent" = "PowerShell" } -ErrorAction Stop
+        $vcpkgBaseline = $response.sha
+        Write-Host "vcpkg baseline: $vcpkgBaseline"
+    }
+    catch {
+        Write-Warning "Failed to fetch latest vcpkg commit; using hard-coded baseline."
+    }
+
     Copy-Item ($TemplateDir + "\vcpkg*.json") -Destination $TargetDir
 
     $vcpkgConfig = $TargetDir + "\vcpkg-configuration.json"

--- a/VSIX/createmsbuild.ps1
+++ b/VSIX/createmsbuild.ps1
@@ -94,7 +94,7 @@ param (
     [bool]$makepfx = $false
 )
 
-$vcpkgBaseline = "670f6dddaafc59c5dfe0587a130d59a35c48ea38"
+$vcpkgBaseline = "f3e10653cc27d62a37a3763cd84b38bca07c6075"
 
 if (-Not ($PlatformToolset -match 'v[0-9][0-9][0-9]'))
 {
@@ -169,6 +169,17 @@ Rename-Item -Path ($TargetDir + "\" + $projfile) -NewName ($ProjectName + ".vcxp
 Rename-Item -Path ($TargetDir + "\" + $filterfile) -NewName ($ProjectName + ".vcxproj.filters")
 
 if (Test-Path -Path ($TemplateDir + "\vcpkg.json")) {
+
+    try {
+        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/microsoft/vcpkg/commits/master" `
+            -Headers @{ "User-Agent" = "PowerShell" } -ErrorAction Stop
+        $vcpkgBaseline = $response.sha
+        Write-Host "vcpkg baseline: $vcpkgBaseline"
+    }
+    catch {
+        Write-Warning "Failed to fetch latest vcpkg commit; using hard-coded baseline."
+    }
+
     Copy-Item ($TemplateDir + "\vcpkg*.json") -Destination $TargetDir
 
     $vcpkgConfig = $TargetDir + "\vcpkg-configuration.json"


### PR DESCRIPTION
I have two PowerShell scripts for instancing templates without VS. For the vcpkg templates, they were using hard-coded values. Now they use HEAD if possible.